### PR TITLE
[UI] Improve form validation feedback and scrollbar styling

### DIFF
--- a/Resources/Styles.xaml
+++ b/Resources/Styles.xaml
@@ -86,6 +86,21 @@
         </Style.Triggers>
     </Style>
 
+    <Style x:Key="ValidatedTextBoxStyle" TargetType="TextBox" BasedOn="{StaticResource BaseTextBoxStyle}">
+        <Setter Property="Padding" Value="6,4,28,4" />
+        <Style.Triggers>
+            <Trigger Property="IsFocused" Value="True">
+                <Setter Property="BorderBrush" Value="{StaticResource AccentOrangeBrush}"/>
+                <Setter Property="Background" Value="{StaticResource DarkBackgroundBaseBrush}"/>
+                <Setter Property="Effect">
+                    <Setter.Value>
+                        <DropShadowEffect Color="#60000000" Direction="90" ShadowDepth="0.5" BlurRadius="1" Opacity="0.2"/>
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
     <Style TargetType="ComboBox">
         <Setter Property="Background" Value="{StaticResource DarkBackgroundDeeperBrush}"/>
         <Setter Property="Foreground" Value="{StaticResource LightTextBrush}"/>
@@ -1213,6 +1228,33 @@
                 </Trigger.EnterActions>
             </Trigger>
         </Style.Triggers>
+    </Style>
+
+<Style TargetType="ScrollBar">
+        <Setter Property="Width" Value="6" />
+        <Setter Property="MinWidth" Value="6" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ScrollBar">
+                    <Grid>
+                        <Track x:Name="PART_Track" IsDirectionReversed="True">
+                            <Track.Thumb>
+                                <Thumb>
+                                    <Thumb.Template>
+                                        <ControlTemplate TargetType="Thumb">
+                                            <Border Background="{StaticResource DarkHoverElevatedBrush}"
+                                                    CornerRadius="3"
+                                                    Margin="0,2" />
+                                        </ControlTemplate>
+                                    </Thumb.Template>
+                                </Thumb>
+                            </Track.Thumb>
+                        </Track>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
 </ResourceDictionary>

--- a/Views/Controls/ValidatedTextBox.xaml
+++ b/Views/Controls/ValidatedTextBox.xaml
@@ -3,22 +3,63 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:controls="clr-namespace:Schedule1ModdingTool.Views.Controls"
              mc:Ignorable="d"
-             d:DesignHeight="50" d:DesignWidth="300">
-    <StackPanel>
-        <TextBox x:Name="InnerTextBox"
-                 Text="{Binding Text, RelativeSource={RelativeSource AncestorType=UserControl}, UpdateSourceTrigger=PropertyChanged}"
-                 Style="{StaticResource TextBoxStyle}"
-                 LostFocus="InnerTextBox_LostFocus"
-                 TextChanged="InnerTextBox_TextChanged"/>
-        <TextBlock x:Name="ErrorTextBlock"
-                   Text="{Binding ErrorMessage, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                   Foreground="{StaticResource ErrorBrush}"
-                   FontSize="11"
-                   Margin="4,2,0,0"
-                   Visibility="{Binding IsValid, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource InverseBooleanToVisibilityConverter}}"
-                   TextWrapping="Wrap"/>
-    </StackPanel>
-</UserControl>
+             d:DesignHeight="60" d:DesignWidth="300">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
 
+        <Grid Grid.Row="0">
+            <TextBox x:Name="InnerTextBox"
+                     Text="{Binding Text, RelativeSource={RelativeSource AncestorType=UserControl}, UpdateSourceTrigger=PropertyChanged}"
+                     Style="{StaticResource ValidatedTextBoxStyle}"
+                     LostFocus="InnerTextBox_LostFocus"
+                     TextChanged="InnerTextBox_TextChanged" />
+
+            <materialDesign:PackIcon x:Name="ValidationIcon"
+                                     Width="16"
+                                     Height="16"
+                                     VerticalAlignment="Center"
+                                     HorizontalAlignment="Right"
+                                     Margin="0,0,8,0"
+                                     Visibility="Collapsed">
+                <materialDesign:PackIcon.Style>
+                    <Style TargetType="materialDesign:PackIcon">
+                        <Setter Property="Kind" Value="CheckCircle" />
+                        <Setter Property="Foreground" Value="{StaticResource SuccessBrush}" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsValid, RelativeSource={RelativeSource AncestorType=UserControl}}" Value="False">
+                                <Setter Property="Kind" Value="AlertCircle" />
+                                <Setter Property="Foreground" Value="{StaticResource ErrorBrush}" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </materialDesign:PackIcon.Style>
+            </materialDesign:PackIcon>
+        </Grid>
+
+        <TextBlock x:Name="ErrorTextBlock"
+                   Grid.Row="1"
+                   Text="{Binding ErrorMessage, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                   FontSize="11"
+                   Margin="4,4,0,0"
+                   TextWrapping="Wrap">
+            <TextBlock.Style>
+                <Style TargetType="TextBlock">
+                    <Setter Property="Foreground" Value="{StaticResource ErrorBrush}" />
+                    <Setter Property="Visibility" Value="Collapsed" />
+                    <Setter Property="Opacity" Value="0.9" />
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding IsValid, RelativeSource={RelativeSource AncestorType=UserControl}}" Value="False">
+                            <Setter Property="Visibility" Value="Visible" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBlock.Style>
+        </TextBlock>
+    </Grid>
+</UserControl>

--- a/Views/Controls/ValidatedTextBox.xaml.cs
+++ b/Views/Controls/ValidatedTextBox.xaml.cs
@@ -6,75 +6,108 @@ using Schedule1ModdingTool.Utils;
 namespace Schedule1ModdingTool.Views.Controls
 {
     /// <summary>
-    /// Interaction logic for ValidatedTextBox.xaml
+    /// A text input control with real-time validation and visual feedback.
+    /// Displays validation icons (checkmark/alert) and error messages based on the ValidationType.
     /// </summary>
     public partial class ValidatedTextBox : UserControl
     {
+        /// <summary>
+        /// Identifies the Text dependency property.
+        /// </summary>
         public static readonly DependencyProperty TextProperty =
             DependencyProperty.Register(nameof(Text), typeof(string), typeof(ValidatedTextBox),
                 new FrameworkPropertyMetadata(string.Empty, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnTextChanged));
 
+        /// <summary>
+        /// Identifies the ValidationType dependency property.
+        /// </summary>
         public static readonly DependencyProperty ValidationTypeProperty =
             DependencyProperty.Register(nameof(ValidationType), typeof(ValidationType), typeof(ValidatedTextBox),
                 new PropertyMetadata(ValidationType.NpcId, OnValidationTypeChanged));
 
+        /// <summary>
+        /// Identifies the IsValid dependency property.
+        /// </summary>
         public static readonly DependencyProperty IsValidProperty =
             DependencyProperty.Register(nameof(IsValid), typeof(bool), typeof(ValidatedTextBox),
                 new PropertyMetadata(true));
 
+        /// <summary>
+        /// Identifies the ErrorMessage dependency property.
+        /// </summary>
         public static readonly DependencyProperty ErrorMessageProperty =
             DependencyProperty.Register(nameof(ErrorMessage), typeof(string), typeof(ValidatedTextBox),
                 new PropertyMetadata(string.Empty));
 
+        /// <summary>
+        /// Identifies the AutoCorrect dependency property.
+        /// </summary>
         public static readonly DependencyProperty AutoCorrectProperty =
             DependencyProperty.Register(nameof(AutoCorrect), typeof(bool), typeof(ValidatedTextBox),
                 new PropertyMetadata(true));
 
+        /// <summary>
+        /// Initializes a new instance of the ValidatedTextBox control.
+        /// </summary>
         public ValidatedTextBox()
         {
             InitializeComponent();
             Loaded += ValidatedTextBox_Loaded;
         }
 
-        protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e)
-        {
-            base.OnPropertyChanged(e);
-            
-            // Revalidate when Tag (FieldType) changes for DataClassDefaultValue validation
-            if (e.Property == TagProperty && ValidationType == ValidationType.DataClassDefaultValue)
-            {
-                Validate();
-            }
-        }
-
+        /// <summary>
+        /// Gets or sets the text content of the textbox.
+        /// </summary>
         public string Text
         {
             get => (string)GetValue(TextProperty);
             set => SetValue(TextProperty, value);
         }
 
+        /// <summary>
+        /// Gets or sets the type of validation to apply to the text.
+        /// </summary>
         public ValidationType ValidationType
         {
             get => (ValidationType)GetValue(ValidationTypeProperty);
             set => SetValue(ValidationTypeProperty, value);
         }
 
+        /// <summary>
+        /// Gets whether the current text passes validation.
+        /// </summary>
         public bool IsValid
         {
             get => (bool)GetValue(IsValidProperty);
             private set => SetValue(IsValidProperty, value);
         }
 
+        /// <summary>
+        /// Gets the error message if validation failed.
+        /// </summary>
         public string ErrorMessage
         {
             get => (string)GetValue(ErrorMessageProperty);
             private set => SetValue(ErrorMessageProperty, value);
         }
 
+        /// <summary>
+        /// Gets or sets whether to auto-correct invalid values on focus loss.
+        /// </summary>
         public bool AutoCorrect
         {
             get => (bool)GetValue(AutoCorrectProperty);
             set => SetValue(AutoCorrectProperty, value);
+        }
+
+        protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e)
+        {
+            base.OnPropertyChanged(e);
+            
+            if (e.Property == TagProperty && ValidationType == ValidationType.DataClassDefaultValue)
+            {
+                Validate();
+            }
         }
 
         private void ValidatedTextBox_Loaded(object sender, RoutedEventArgs e)
@@ -112,6 +145,9 @@ namespace Schedule1ModdingTool.Views.Controls
             Validate();
         }
 
+        /// <summary>
+        /// Validates the current text against the ValidationType and updates visual state.
+        /// </summary>
         public void Validate()
         {
             bool isValid;
@@ -144,7 +180,6 @@ namespace Schedule1ModdingTool.Views.Controls
                     break;
 
                 case ValidationType.DataClassDefaultValue:
-                    // Get FieldType from Tag property
                     var fieldType = Tag as DataClassFieldType?;
                     isValid = ValidationHelpers.IsValidDefaultValue(Text, fieldType);
                     if (!isValid)
@@ -160,8 +195,6 @@ namespace Schedule1ModdingTool.Views.Controls
 
             IsValid = isValid;
             ErrorMessage = errorMessage;
-
-            // Update visual state
             UpdateVisualState();
         }
 
@@ -184,7 +217,6 @@ namespace Schedule1ModdingTool.Views.Controls
                     break;
 
                 case ValidationType.DataClassDefaultValue:
-                    // Don't auto-correct default values - let user fix manually
                     break;
             }
 
@@ -196,29 +228,52 @@ namespace Schedule1ModdingTool.Views.Controls
 
         private void UpdateVisualState()
         {
-            if (InnerTextBox == null) return;
+            if (InnerTextBox == null || ValidationIcon == null) return;
 
-            if (IsValid)
+            if (IsValid && !string.IsNullOrWhiteSpace(Text))
             {
-                InnerTextBox.BorderBrush = Application.Current.Resources["DarkBorderBrush"] as System.Windows.Media.Brush;
+                InnerTextBox.BorderBrush = Application.Current.Resources["SuccessBrush"] as System.Windows.Media.Brush;
                 InnerTextBox.BorderThickness = new Thickness(1);
+                ValidationIcon.Visibility = Visibility.Visible;
             }
-            else
+            else if (!IsValid)
             {
                 InnerTextBox.BorderBrush = Application.Current.Resources["ErrorBrush"] as System.Windows.Media.Brush;
                 InnerTextBox.BorderThickness = new Thickness(2);
+                ValidationIcon.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                InnerTextBox.BorderBrush = Application.Current.Resources["DarkBorderBrush"] as System.Windows.Media.Brush;
+                InnerTextBox.BorderThickness = new Thickness(1);
+                ValidationIcon.Visibility = Visibility.Collapsed;
             }
         }
     }
 
     /// <summary>
-    /// Enumeration of validation types for ValidatedTextBox
+    /// Specifies the validation rules for ValidatedTextBox.
     /// </summary>
     public enum ValidationType
     {
+        /// <summary>
+        /// Validates NPC identifiers (e.g., "npc_drugdealer_01").
+        /// </summary>
         NpcId,
+
+        /// <summary>
+        /// Validates quest identifiers (e.g., "quest_intro_01").
+        /// </summary>
         QuestId,
+
+        /// <summary>
+        /// Validates C# class names (must start with letter, alphanumeric).
+        /// </summary>
         ClassName,
+
+        /// <summary>
+        /// Validates default values for data class fields based on field type.
+        /// </summary>
         DataClassDefaultValue
     }
 }

--- a/Views/SettingsWindow.xaml
+++ b/Views/SettingsWindow.xaml
@@ -27,8 +27,8 @@
 
 			<TextBlock Grid.Row="0" Text="Mod Generation Settings" FontSize="16" FontWeight="Bold" Margin="0,0,0,10" />
 
-			<ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" Padding="0,0,5,0">
-				<StackPanel Orientation="Vertical">
+			<ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+				<StackPanel Orientation="Vertical" Margin="0,0,8,0">
 				<GroupBox Header="Workspace" Margin="0,0,0,8">
 					<StackPanel Margin="5">
 						<TextBlock Text="Default Workspace Path:" Margin="0,0,0,5" />


### PR DESCRIPTION
## Description
- Add visual validation icons (checkmark/alert) to ValidatedTextBox control
- Slim down scrollbar styling across the application
- Fix scrollbar spacing in Settings window

## Motivation
Wasn't able to tell if input was valid easily.
The old scrollbar was chunky.

## Changes

### ValidatedTextBox 
- Added inline validation icon (green checkmark for valid, red alert for invalid)
- Updated border colors based on validation state
- Added new ValidatedTextBoxStyle with right padding for icon

### Scrollbar Styling  
- Reduced scrollbar width from default to 6px
- Added subtle, rounded thumb styling
- Fixed Settings window scrollbar spacing

## Testing
- [x] Project builds without errors
- [x] Application launches
- [x] Changes work 

## Screenshots

BEFORE SCROLLBAR
<img width="570" height="680" alt="Screenshot 2026-04-25 002732" src="https://github.com/user-attachments/assets/72aa39f6-32d1-400b-a000-079a981033bc" />

AFTER SCROLLBAR AND NEW VALIDATION
<img width="586" height="693" alt="Screenshot 2026-04-25 003051" src="https://github.com/user-attachments/assets/cc0e812c-d50b-43da-b574-11ca640559af" />

<img width="328" height="215" alt="Screenshot 2026-04-25 003722" src="https://github.com/user-attachments/assets/fe593700-f0a3-42ae-afc5-633f0afc3441" />

